### PR TITLE
fix: ADO 1908: Disabled event-handler service webhook which is no longer in use

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -29,8 +29,8 @@ flock:
   enabled: false
   # url: ""
 webhook:
-  enabled: true
-  url: "http://devtroncd-event-handler-service-prod.devtroncd"
+  enabled: false
+  #url: ""
 
 # Resources to watch
 resourcesToWatch:


### PR DESCRIPTION
Disabled event handler service webhook